### PR TITLE
Fix warnings

### DIFF
--- a/src/Zicht/Tool/Command/TaskCommand.php
+++ b/src/Zicht/Tool/Command/TaskCommand.php
@@ -69,15 +69,15 @@ class TaskCommand extends BaseCommand
         }
     }
 
-    public function addOption($name, $shortcut = null, $mode = null, $help = null)
+    public function addOption($name, $shortcut = null, $mode = null, $help = null, $default = null)
     {
         $helpTag = ($mode === InputOption::VALUE_NONE) ? "--$name" : "--$name=" . strtoupper($name);
-        return parent::addOption($name, $shortcut, $mode, $help ?: $this->parseHelp($helpTag));
+        return parent::addOption($name, $shortcut, $mode, $help ?: $this->parseHelp($helpTag), $default);
     }
 
-    public function addArgument($name, $mode = null, $help = null)
+    public function addArgument($name, $mode = null, $help = null, $default = null)
     {
-        return parent::addArgument($name, $mode, $help ?: $this->parseHelp($name));
+        return parent::addArgument($name, $mode, $help ?: $this->parseHelp($name), $default);
     }
 
 


### PR DESCRIPTION
On my development machine I always get warnings when I call a z task. These warnings about the methods `addOption` and `addArgument` of the `TaskCommand` that are not compatible with the parent class.

I added the argument with the same default as the parent class to fix the warning.