### PR TITLE
Remove suggest to obsolete z-plugins package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,6 @@
         "zicht/version": "1.*@stable",
         "zicht/util": "1.*@stable"
     },
-    "suggest": {
-        "zicht/z-plugins": "A set of default plugins for Z"
-    },
     "scripts": {
         "post-install-cmd": [
         ],


### PR DESCRIPTION
As stated here https://github.com/zicht/z-plugins this has become obsolete over the separately managed plugins.