### PR TITLE
Explain: Clean up command string before output

### DIFF
--- a/src/Zicht/Tool/Container/Container.php
+++ b/src/Zicht/Tool/Container/Container.php
@@ -503,11 +503,12 @@ class Container
             }
 
             if ($this->resolve('EXPLAIN')) {
+                $cleanCmd = preg_replace(array("/\n *\\\\\n/", '/( +\\\\)+$/m'), array('', ' \\'), trim($cmd));
                 if ($this->resolve('INTERACTIVE')) {
                     $this->notice('interactive shell:');
-                    $line = '( /bin/bash -c \'' . trim($cmd) . '\' )';
+                    $line = '( /bin/bash -c \'' . $cleanCmd . '\' )';
                 } else {
-                    $line = 'echo ' . escapeshellarg(trim($cmd)) . ' | ' . $this->resolve(array('SHELL'));
+                    $line = 'echo ' . escapeshellarg($cleanCmd) . ' | ' . $this->resolve(array('SHELL'));
                 }
                 $this->output->writeln($line);
             } else {


### PR DESCRIPTION
* Cleans empty lines (caused by conditional statements, evaluating to false)
* Cleans white space at the end of lines

Before:
```bash
$ z solr:reindex testing --explain
echo 'cd /media/data/domains/mokveld.com/ && \
    php app/console zicht:solr:reindex      \
         \
           \
        --env=testing' | ssh zichter@testing.zicht.intern
```

After:
```bash
$ z solr:reindex testing --explain
echo 'cd /media/data/domains/mokveld.com/ && \
    php app/console zicht:solr:reindex \
        --env=testing' | ssh zichter@testing.zicht.intern
```