### PR TITLE
Add -l flag to SHELL - all commands are now .bash_profile aware

### DIFF
--- a/src/Zicht/Tool/Container/Container.php
+++ b/src/Zicht/Tool/Container/Container.php
@@ -53,7 +53,7 @@ class Container
 
         $this->values = array(
             'SHELL'         => function ($z) {
-                return '/bin/bash -e' . ($z->has('DEBUG') && $z->get('DEBUG') ? 'x' : '');
+                return '/bin/bash -el' . ($z->has('DEBUG') && $z->get('DEBUG') ? 'x' : '');
             },
             'TIMEOUT'       => null,
             'INTERACTIVE'   => false,


### PR DESCRIPTION
This fixes user specific configurations, such as a different $PATH when executing a statement on a remote machine using ssh.

My specific use-case involved the `~/.profile` setting an alternative config revealing the php binary available on that system.  Without the login shell this is not available.

Some serious testing should be done before applying this patch, because it will have consequences.